### PR TITLE
change storage's controller to interface.

### DIFF
--- a/src/main/java/org/signal/storageservice/StorageService.java
+++ b/src/main/java/org/signal/storageservice/StorageService.java
@@ -57,6 +57,9 @@ import org.signal.storageservice.s3.PostPolicyGenerator;
 import org.signal.storageservice.storage.BackupsManager;
 import org.signal.storageservice.storage.GroupsManager;
 import org.signal.storageservice.storage.StorageManager;
+import org.signal.storageservice.storage.bigtable.BigTableBackupsManager;
+import org.signal.storageservice.storage.bigtable.BigTableGroupsManager;
+import org.signal.storageservice.storage.bigtable.BigTableStorageManager;
 import org.signal.storageservice.util.HostnameUtil;
 import org.signal.storageservice.util.UncaughtExceptionHandler;
 import org.signal.storageservice.util.logging.LoggingUnhandledExceptionMapper;
@@ -100,9 +103,9 @@ public class StorageService extends Application<StorageServiceConfiguration> {
                                                                     .build();
     BigtableDataClient bigtableDataClient = BigtableDataClient.create(bigtableDataSettings);
     ServerSecretParams serverSecretParams = new ServerSecretParams(config.getZkConfiguration().getServerSecret());
-    StorageManager     storageManager     = new StorageManager(bigtableDataClient, config.getBigTableConfiguration().getContactManifestsTableId(), config.getBigTableConfiguration().getContactsTableId());
-    GroupsManager      groupsManager      = new GroupsManager(bigtableDataClient, config.getBigTableConfiguration().getGroupsTableId(), config.getBigTableConfiguration().getGroupLogsTableId());
-    BackupsManager backupsManager = new BackupsManager(bigtableTableAdminClient, config.getBigTableConfiguration().getClusterId(), List.of(
+    StorageManager     storageManager     = new BigTableStorageManager(bigtableDataClient, config.getBigTableConfiguration().getContactManifestsTableId(), config.getBigTableConfiguration().getContactsTableId());
+    GroupsManager      groupsManager      = new BigTableGroupsManager(bigtableDataClient, config.getBigTableConfiguration().getGroupsTableId(), config.getBigTableConfiguration().getGroupLogsTableId());
+    BackupsManager backupsManager = new BigTableBackupsManager(bigtableTableAdminClient, config.getBigTableConfiguration().getClusterId(), List.of(
             config.getBigTableConfiguration().getContactManifestsTableId(),
             config.getBigTableConfiguration().getContactsTableId(),
             config.getBigTableConfiguration().getGroupLogsTableId(),

--- a/src/main/java/org/signal/storageservice/controllers/StorageController.java
+++ b/src/main/java/org/signal/storageservice/controllers/StorageController.java
@@ -30,7 +30,7 @@ import javax.ws.rs.core.Response.Status;
 import org.signal.storageservice.auth.User;
 import org.signal.storageservice.metrics.UserAgentTagUtil;
 import org.signal.storageservice.providers.ProtocolBufferMediaType;
-import org.signal.storageservice.storage.StorageItemsTable;
+import org.signal.storageservice.storage.bigtable.StorageItemsTable;
 import org.signal.storageservice.storage.StorageManager;
 import org.signal.storageservice.storage.protos.contacts.ReadOperation;
 import org.signal.storageservice.storage.protos.contacts.StorageItems;

--- a/src/main/java/org/signal/storageservice/storage/BackupsManager.java
+++ b/src/main/java/org/signal/storageservice/storage/BackupsManager.java
@@ -5,73 +5,10 @@
 
 package org.signal.storageservice.storage;
 
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutureCallback;
-import com.google.api.core.ApiFutures;
-import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.admin.v2.models.Backup;
-import com.google.cloud.bigtable.admin.v2.models.CreateBackupRequest;
-import com.google.common.util.concurrent.MoreExecutors;
-import org.signal.storageservice.util.Pair;
-
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
-public class BackupsManager {
-  private static final DateTimeFormatter BACKUP_ID_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.US).withZone(ZoneOffset.UTC);
-
-  private final BigtableTableAdminClient client;
-  private final String clusterId;
-  private final Collection<String> tableIds;
-
-  public BackupsManager(BigtableTableAdminClient client, String clusterId, Collection<String> tableIds) {
-    this.client = client;
-    this.clusterId = clusterId;
-    this.tableIds = tableIds;
-  }
-
-  public CompletableFuture<Map<String, Backup>> createBackups() {
-    final Instant backupTime = Instant.now();
-    final Instant expireTime = backupTime.plus(7, ChronoUnit.DAYS);
-    final ArrayList<CompletableFuture<Pair<String, Backup>>> futures = new ArrayList<>(tableIds.size());
-    for (String tableId : tableIds) {
-      final CreateBackupRequest request = CreateBackupRequest.of(clusterId, createBackupId(tableId, backupTime));
-      request.setExpireTime(convertInstantToBigtableInstant(expireTime));
-      request.setSourceTableId(tableId);
-      final CompletableFuture<Pair<String, Backup>> completableFuture = new CompletableFuture<>();
-      final ApiFuture<Backup> apiFuture = client.createBackupAsync(request);
-      ApiFutures.addCallback(apiFuture, new ApiFutureCallback<>() {
-        @Override
-        public void onFailure(Throwable t) {
-          completableFuture.completeExceptionally(t);
-        }
-
-        @Override
-        public void onSuccess(Backup result) {
-          completableFuture.complete(new Pair<>(tableId, result));
-        }
-      }, MoreExecutors.directExecutor());
-      futures.add(completableFuture);
-    }
-    final CompletableFuture<Void> completableFuture = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-    return completableFuture.thenApply(v -> futures.stream()
-                                                   .map(CompletableFuture::join)
-                                                   .collect(Collectors.toMap(Pair::first, Pair::second)));
-  }
-
-  private static String createBackupId(final String tableId, final Instant backupTime) {
-    return BACKUP_ID_FORMATTER.format(backupTime) + '-' + tableId;
-  }
-
-  private static org.threeten.bp.Instant convertInstantToBigtableInstant(final Instant instant) {
-    return org.threeten.bp.Instant.ofEpochSecond(instant.getEpochSecond(), instant.getNano());
-  }
+public interface BackupsManager {
+  CompletableFuture<Map<String, Backup>> createBackups();
 }

--- a/src/main/java/org/signal/storageservice/storage/GroupsManager.java
+++ b/src/main/java/org/signal/storageservice/storage/GroupsManager.java
@@ -5,7 +5,6 @@
 
 package org.signal.storageservice.storage;
 
-import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.protobuf.ByteString;
 import java.util.List;
 import java.util.Optional;
@@ -15,55 +14,18 @@ import org.signal.storageservice.storage.protos.groups.GroupChange;
 import org.signal.storageservice.storage.protos.groups.GroupChanges.GroupChangeState;
 import javax.annotation.Nullable;
 
-public class GroupsManager {
+public interface GroupsManager {
 
-  private final GroupsTable   groupsTable;
-  private final GroupLogTable groupLogTable;
+  CompletableFuture<Optional<Group>> getGroup(ByteString groupId);
 
-  public GroupsManager(BigtableDataClient client, String groupsTableId, String groupLogsTableId) {
-    this.groupsTable   = new GroupsTable  (client, groupsTableId   );
-    this.groupLogTable = new GroupLogTable(client, groupLogsTableId);
-  }
+  CompletableFuture<Boolean> createGroup(ByteString groupId, Group group);
 
-  public CompletableFuture<Optional<Group>> getGroup(ByteString groupId) {
-    return groupsTable.getGroup(groupId);
-  }
+  CompletableFuture<Optional<Group>> updateGroup(ByteString groupId, Group group);
 
-  public CompletableFuture<Boolean> createGroup(ByteString groupId, Group group) {
-    return groupsTable.createGroup(groupId, group);
-  }
 
-  public CompletableFuture<Optional<Group>> updateGroup(ByteString groupId, Group group) {
-    return groupsTable.updateGroup(groupId, group)
-                      .thenCompose(modified -> {
-                        if (modified) return CompletableFuture.completedFuture(Optional.empty());
-                        else          return getGroup(groupId).thenApply(result -> Optional.of(result.orElseThrow()));
-                      });
-  }
-
-  public CompletableFuture<List<GroupChangeState>> getChangeRecords(ByteString groupId, Group group,
+  CompletableFuture<List<GroupChangeState>> getChangeRecords(ByteString groupId, Group group,
       @Nullable Integer maxSupportedChangeEpoch, boolean includeFirstState, boolean includeLastState,
-      int fromVersionInclusive, int toVersionExclusive) {
-    if (fromVersionInclusive >= toVersionExclusive) {
-      throw new IllegalArgumentException("Version to read from (" + fromVersionInclusive + ") must be less than version to read to (" + toVersionExclusive + ")");
-    }
+      int fromVersionInclusive, int toVersionExclusive);
 
-    return groupLogTable.getRecordsFromVersion(groupId, maxSupportedChangeEpoch, includeFirstState, includeLastState, fromVersionInclusive, toVersionExclusive, group.getVersion())
-                        .thenApply(groupChangeStatesAndSeenCurrentVersion -> {
-                          List<GroupChangeState> groupChangeStates = groupChangeStatesAndSeenCurrentVersion.first();
-                          boolean seenCurrentVersion = groupChangeStatesAndSeenCurrentVersion.second();
-                          if (isGroupInRange(group, fromVersionInclusive, toVersionExclusive) && !seenCurrentVersion && toVersionExclusive - 1 == group.getVersion()) {
-                            groupChangeStates.add(GroupChangeState.newBuilder().setGroupState(group).build());
-                          }
-                          return groupChangeStates;
-                        });
-  }
-
-  public CompletableFuture<Boolean> appendChangeRecord(ByteString groupId, int version, GroupChange change, Group state) {
-    return groupLogTable.append(groupId, version, change, state);
-  }
-
-  private static boolean isGroupInRange(Group group, int fromVersionInclusive, int toVersionExclusive) {
-    return fromVersionInclusive <= group.getVersion() && group.getVersion() < toVersionExclusive;
-  }
+  CompletableFuture<Boolean> appendChangeRecord(ByteString groupId, int version, GroupChange change, Group state);
 }

--- a/src/main/java/org/signal/storageservice/storage/StorageManager.java
+++ b/src/main/java/org/signal/storageservice/storage/StorageManager.java
@@ -5,31 +5,18 @@
 
 package org.signal.storageservice.storage;
 
-import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.protobuf.ByteString;
 import org.signal.storageservice.auth.User;
+import org.signal.storageservice.storage.bigtable.StorageManifestsTable;
 import org.signal.storageservice.storage.protos.contacts.StorageItem;
 import org.signal.storageservice.storage.protos.contacts.StorageManifest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-public class StorageManager {
-
-  private final StorageManifestsTable manifestsTable;
-  private final StorageItemsTable     itemsTable;
-
-  private static final Logger log = LoggerFactory.getLogger(StorageManager.class);
-
-  public StorageManager(BigtableDataClient client, String contactManifestsTableId, String contactsTableId) {
-    this.manifestsTable = new StorageManifestsTable(client, contactManifestsTableId);
-    this.itemsTable     = new StorageItemsTable(client, contactsTableId);
-  }
-
-  /**
+public interface StorageManager {
+    /**
    * Updates a manifest and applies mutations to stored items.
    *
    * @param user the user for whom to update manifests and mutate stored items
@@ -43,54 +30,15 @@ public class StorageManager {
    *
    * @see StorageManifestsTable#set(User, StorageManifest)
    */
-  public CompletableFuture<Optional<StorageManifest>> set(User user, StorageManifest manifest, List<StorageItem> inserts, List<ByteString> deletes) {
-    return manifestsTable.set(user, manifest)
-                         .thenCompose(manifestUpdated -> {
-                           if (manifestUpdated) {
-                             return inserts.isEmpty() && deletes.isEmpty()
-                                 ? CompletableFuture.completedFuture(Optional.empty())
-                                 : itemsTable.set(user, inserts, deletes).thenApply(nothing -> Optional.empty());
-                           } else {
-                             // The new manifest's version wasn't the expected value, and it's likely that the manifest
-                             // was updated by a separate thread/process. Return a copy of the most recent stored
-                             // manifest.
-                             return getManifest(user).thenApply(retrieved -> Optional.of(retrieved.orElseThrow()));
-                           }
-                         });
-  }
+  CompletableFuture<Optional<StorageManifest>> set(User user, StorageManifest manifest, List<StorageItem> inserts, List<ByteString> deletes);
 
-  public CompletableFuture<Optional<StorageManifest>> getManifest(User user) {
-    return manifestsTable.get(user);
-  }
+  CompletableFuture<Optional<StorageManifest>> getManifest(User user) ;
 
-  public CompletableFuture<Optional<StorageManifest>> getManifestIfNotVersion(User user, long version) {
-    return manifestsTable.getIfNotVersion(user, version);
-  }
+  CompletableFuture<Optional<StorageManifest>> getManifestIfNotVersion(User user, long version);
 
-  public CompletableFuture<List<StorageItem>> getItems(User user, List<ByteString> keys) {
-    return itemsTable.get(user, keys);
-  }
+  CompletableFuture<List<StorageItem>> getItems(User user, List<ByteString> keys);
 
-  public CompletableFuture<Void> clearItems(User user) {
-    return itemsTable.clear(user).whenComplete((ignored, throwable) -> {
-          if (throwable != null) {
-            log.warn("Failed to clear stored items", throwable);
-          }
-        });
-  }
+  CompletableFuture<Void> clearItems(User user);
 
-  public CompletableFuture<Void> delete(User user) {
-    return CompletableFuture.allOf(
-        itemsTable.clear(user).whenComplete((ignored, throwable) -> {
-          if (throwable != null) {
-            log.warn("Failed to delete stored items", throwable);
-          }
-        }),
-
-        manifestsTable.clear(user).whenComplete((ignored, throwable) -> {
-          if (throwable != null) {
-            log.warn("Failed to delete manifest", throwable);
-          }
-        }));
-  }
+  CompletableFuture<Void> delete(User user);
 }

--- a/src/main/java/org/signal/storageservice/storage/bigtable/BigTableBackupsManager.java
+++ b/src/main/java/org/signal/storageservice/storage/bigtable/BigTableBackupsManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.signal.storageservice.storage.bigtable;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.models.Backup;
+import com.google.cloud.bigtable.admin.v2.models.CreateBackupRequest;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.signal.storageservice.storage.BackupsManager;
+import org.signal.storageservice.util.Pair;
+
+public class BigTableBackupsManager implements BackupsManager {
+  private static final DateTimeFormatter BACKUP_ID_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.US).withZone(ZoneOffset.UTC);
+
+  private final BigtableTableAdminClient client;
+  private final String clusterId;
+  private final Collection<String> tableIds;
+
+  public BigTableBackupsManager(BigtableTableAdminClient client, String clusterId, Collection<String> tableIds) {
+    this.client = client;
+    this.clusterId = clusterId;
+    this.tableIds = tableIds;
+  }
+
+  public CompletableFuture<Map<String, Backup>> createBackups() {
+    final Instant backupTime = Instant.now();
+    final Instant expireTime = backupTime.plus(7, ChronoUnit.DAYS);
+    final ArrayList<CompletableFuture<Pair<String, Backup>>> futures = new ArrayList<>(tableIds.size());
+    for (String tableId : tableIds) {
+      final CreateBackupRequest request = CreateBackupRequest.of(clusterId, createBackupId(tableId, backupTime));
+      request.setExpireTime(convertInstantToBigtableInstant(expireTime));
+      request.setSourceTableId(tableId);
+      final CompletableFuture<Pair<String, Backup>> completableFuture = new CompletableFuture<>();
+      final ApiFuture<Backup> apiFuture = client.createBackupAsync(request);
+      ApiFutures.addCallback(apiFuture, new ApiFutureCallback<>() {
+        @Override
+        public void onFailure(Throwable t) {
+          completableFuture.completeExceptionally(t);
+        }
+
+        @Override
+        public void onSuccess(Backup result) {
+          completableFuture.complete(new Pair<>(tableId, result));
+        }
+      }, MoreExecutors.directExecutor());
+      futures.add(completableFuture);
+    }
+    final CompletableFuture<Void> completableFuture = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    return completableFuture.thenApply(v -> futures.stream()
+                                                   .map(CompletableFuture::join)
+                                                   .collect(Collectors.toMap(Pair::first, Pair::second)));
+  }
+
+  private static String createBackupId(final String tableId, final Instant backupTime) {
+    return BACKUP_ID_FORMATTER.format(backupTime) + '-' + tableId;
+  }
+
+  private static org.threeten.bp.Instant convertInstantToBigtableInstant(final Instant instant) {
+    return org.threeten.bp.Instant.ofEpochSecond(instant.getEpochSecond(), instant.getNano());
+  }
+}

--- a/src/main/java/org/signal/storageservice/storage/bigtable/BigTableGroupsManager.java
+++ b/src/main/java/org/signal/storageservice/storage/bigtable/BigTableGroupsManager.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.signal.storageservice.storage.bigtable;
+
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.protobuf.ByteString;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+import org.signal.storageservice.storage.GroupsManager;
+import org.signal.storageservice.storage.protos.groups.Group;
+import org.signal.storageservice.storage.protos.groups.GroupChange;
+import org.signal.storageservice.storage.protos.groups.GroupChanges.GroupChangeState;
+
+public class BigTableGroupsManager implements GroupsManager {
+
+  private final GroupsTable groupsTable;
+  private final GroupLogTable groupLogTable;
+
+  public BigTableGroupsManager(BigtableDataClient client, String groupsTableId, String groupLogsTableId) {
+    this.groupsTable   = new GroupsTable  (client, groupsTableId   );
+    this.groupLogTable = new GroupLogTable(client, groupLogsTableId);
+  }
+
+  public CompletableFuture<Optional<Group>> getGroup(ByteString groupId) {
+    return groupsTable.getGroup(groupId);
+  }
+
+  public CompletableFuture<Boolean> createGroup(ByteString groupId, Group group) {
+    return groupsTable.createGroup(groupId, group);
+  }
+
+  public CompletableFuture<Optional<Group>> updateGroup(ByteString groupId, Group group) {
+    return groupsTable.updateGroup(groupId, group)
+                      .thenCompose(modified -> {
+                        if (modified) return CompletableFuture.completedFuture(Optional.empty());
+                        else          return getGroup(groupId).thenApply(result -> Optional.of(result.orElseThrow()));
+                      });
+  }
+
+  public CompletableFuture<List<GroupChangeState>> getChangeRecords(ByteString groupId, Group group,
+      @Nullable Integer maxSupportedChangeEpoch, boolean includeFirstState, boolean includeLastState,
+      int fromVersionInclusive, int toVersionExclusive) {
+    if (fromVersionInclusive >= toVersionExclusive) {
+      throw new IllegalArgumentException("Version to read from (" + fromVersionInclusive + ") must be less than version to read to (" + toVersionExclusive + ")");
+    }
+
+    return groupLogTable.getRecordsFromVersion(groupId, maxSupportedChangeEpoch, includeFirstState, includeLastState, fromVersionInclusive, toVersionExclusive, group.getVersion())
+                        .thenApply(groupChangeStatesAndSeenCurrentVersion -> {
+                          List<GroupChangeState> groupChangeStates = groupChangeStatesAndSeenCurrentVersion.first();
+                          boolean seenCurrentVersion = groupChangeStatesAndSeenCurrentVersion.second();
+                          if (isGroupInRange(group, fromVersionInclusive, toVersionExclusive) && !seenCurrentVersion && toVersionExclusive - 1 == group.getVersion()) {
+                            groupChangeStates.add(GroupChangeState.newBuilder().setGroupState(group).build());
+                          }
+                          return groupChangeStates;
+                        });
+  }
+
+  public CompletableFuture<Boolean> appendChangeRecord(ByteString groupId, int version, GroupChange change, Group state) {
+    return groupLogTable.append(groupId, version, change, state);
+  }
+
+  private static boolean isGroupInRange(Group group, int fromVersionInclusive, int toVersionExclusive) {
+    return fromVersionInclusive <= group.getVersion() && group.getVersion() < toVersionExclusive;
+  }
+}

--- a/src/main/java/org/signal/storageservice/storage/bigtable/BigTableStorageManager.java
+++ b/src/main/java/org/signal/storageservice/storage/bigtable/BigTableStorageManager.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.signal.storageservice.storage.bigtable;
+
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.protobuf.ByteString;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.signal.storageservice.auth.User;
+import org.signal.storageservice.storage.StorageManager;
+import org.signal.storageservice.storage.protos.contacts.StorageItem;
+import org.signal.storageservice.storage.protos.contacts.StorageManifest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BigTableStorageManager implements StorageManager {
+
+  private final StorageManifestsTable manifestsTable;
+  private final StorageItemsTable itemsTable;
+
+  private static final Logger log = LoggerFactory.getLogger(BigTableStorageManager.class);
+
+  public BigTableStorageManager(BigtableDataClient client, String contactManifestsTableId, String contactsTableId) {
+    this.manifestsTable = new StorageManifestsTable(client, contactManifestsTableId);
+    this.itemsTable     = new StorageItemsTable(client, contactsTableId);
+  }
+
+  /**
+   * Updates a manifest and applies mutations to stored items.
+   *
+   * @param user the user for whom to update manifests and mutate stored items
+   * @param manifest the new manifest to store
+   * @param inserts a list of new items to store
+   * @param deletes a list of item identifiers to delete
+   *
+   * @return a future that completes when all updates and mutations have been applied; the future yields an empty value
+   * if all updates and mutations were applied successfully, or the latest stored version of the {@code StorageManifest}
+   * if the given {@code manifest}'s version is not exactly one version ahead of the stored manifest
+   *
+   * @see StorageManifestsTable#set(User, StorageManifest)
+   */
+  public CompletableFuture<Optional<StorageManifest>> set(User user, StorageManifest manifest, List<StorageItem> inserts, List<ByteString> deletes) {
+    return manifestsTable.set(user, manifest)
+                         .thenCompose(manifestUpdated -> {
+                           if (manifestUpdated) {
+                             return inserts.isEmpty() && deletes.isEmpty()
+                                 ? CompletableFuture.completedFuture(Optional.empty())
+                                 : itemsTable.set(user, inserts, deletes).thenApply(nothing -> Optional.empty());
+                           } else {
+                             // The new manifest's version wasn't the expected value, and it's likely that the manifest
+                             // was updated by a separate thread/process. Return a copy of the most recent stored
+                             // manifest.
+                             return getManifest(user).thenApply(retrieved -> Optional.of(retrieved.orElseThrow()));
+                           }
+                         });
+  }
+
+  public CompletableFuture<Optional<StorageManifest>> getManifest(User user) {
+    return manifestsTable.get(user);
+  }
+
+  public CompletableFuture<Optional<StorageManifest>> getManifestIfNotVersion(User user, long version) {
+    return manifestsTable.getIfNotVersion(user, version);
+  }
+
+  public CompletableFuture<List<StorageItem>> getItems(User user, List<ByteString> keys) {
+    return itemsTable.get(user, keys);
+  }
+
+  public CompletableFuture<Void> clearItems(User user) {
+    return itemsTable.clear(user).whenComplete((ignored, throwable) -> {
+          if (throwable != null) {
+            log.warn("Failed to clear stored items", throwable);
+          }
+        });
+  }
+
+  public CompletableFuture<Void> delete(User user) {
+    return CompletableFuture.allOf(
+        itemsTable.clear(user).whenComplete((ignored, throwable) -> {
+          if (throwable != null) {
+            log.warn("Failed to delete stored items", throwable);
+          }
+        }),
+
+        manifestsTable.clear(user).whenComplete((ignored, throwable) -> {
+          if (throwable != null) {
+            log.warn("Failed to delete manifest", throwable);
+          }
+        }));
+  }
+}

--- a/src/main/java/org/signal/storageservice/storage/bigtable/GroupLogTable.java
+++ b/src/main/java/org/signal/storageservice/storage/bigtable/GroupLogTable.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-package org.signal.storageservice.storage;
+package org.signal.storageservice.storage.bigtable;
 
 import static com.codahale.metrics.MetricRegistry.name;
 

--- a/src/main/java/org/signal/storageservice/storage/bigtable/GroupsTable.java
+++ b/src/main/java/org/signal/storageservice/storage/bigtable/GroupsTable.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-package org.signal.storageservice.storage;
+package org.signal.storageservice.storage.bigtable;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;

--- a/src/main/java/org/signal/storageservice/storage/bigtable/StorageItemsTable.java
+++ b/src/main/java/org/signal/storageservice/storage/bigtable/StorageItemsTable.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-package org.signal.storageservice.storage;
+package org.signal.storageservice.storage.bigtable;
 
 import static com.codahale.metrics.MetricRegistry.name;
 

--- a/src/main/java/org/signal/storageservice/storage/bigtable/StorageManifestsTable.java
+++ b/src/main/java/org/signal/storageservice/storage/bigtable/StorageManifestsTable.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-package org.signal.storageservice.storage;
+package org.signal.storageservice.storage.bigtable;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
@@ -14,6 +14,7 @@ import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import org.signal.storageservice.auth.User;
 import org.signal.storageservice.metrics.StorageMetrics;
@@ -27,10 +28,10 @@ import static com.codahale.metrics.MetricRegistry.name;
 
 public class StorageManifestsTable extends Table {
 
-  static final String FAMILY         = "m";
+  public static final String FAMILY         = "m";
 
-  static final String COLUMN_VERSION = "ver";
-  static final String COLUMN_DATA    = "dat";
+  public static final String COLUMN_VERSION = "ver";
+  public static final String COLUMN_DATA    = "dat";
 
   private final MetricRegistry metricRegistry       = SharedMetricRegistries.getOrCreate(StorageMetrics.NAME);
   private final Timer          getTimer             = metricRegistry.timer(name(StorageManifestsTable.class, "get"            ));

--- a/src/main/java/org/signal/storageservice/storage/bigtable/Table.java
+++ b/src/main/java/org/signal/storageservice/storage/bigtable/Table.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-package org.signal.storageservice.storage;
+package org.signal.storageservice.storage.bigtable;
 
 import com.codahale.metrics.Timer;
 import com.google.api.core.ApiFuture;

--- a/src/test/java/org/signal/storageservice/controllers/StorageControllerTest.java
+++ b/src/test/java/org/signal/storageservice/controllers/StorageControllerTest.java
@@ -39,7 +39,7 @@ import org.signal.storageservice.auth.User;
 import org.signal.storageservice.providers.InvalidProtocolBufferExceptionMapper;
 import org.signal.storageservice.providers.ProtocolBufferMediaType;
 import org.signal.storageservice.providers.ProtocolBufferMessageBodyProvider;
-import org.signal.storageservice.storage.StorageItemsTable;
+import org.signal.storageservice.storage.bigtable.StorageItemsTable;
 import org.signal.storageservice.storage.StorageManager;
 import org.signal.storageservice.storage.protos.contacts.ReadOperation;
 import org.signal.storageservice.storage.protos.contacts.StorageItem;

--- a/src/test/java/org/signal/storageservice/storage/BigTableGroupsManagerTest.java
+++ b/src/test/java/org/signal/storageservice/storage/BigTableGroupsManagerTest.java
@@ -34,6 +34,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.signal.libsignal.zkgroup.groups.GroupPublicParams;
 import org.signal.libsignal.zkgroup.groups.GroupSecretParams;
+import org.signal.storageservice.storage.bigtable.BigTableGroupsManager;
+import org.signal.storageservice.storage.bigtable.GroupLogTable;
+import org.signal.storageservice.storage.bigtable.GroupsTable;
 import org.signal.storageservice.storage.protos.groups.AccessControl;
 import org.signal.storageservice.storage.protos.groups.Group;
 import org.signal.storageservice.storage.protos.groups.GroupChange;
@@ -43,7 +46,7 @@ import org.signal.storageservice.storage.protos.groups.GroupChanges.GroupChangeS
 import org.signal.storageservice.util.AuthHelper;
 import org.signal.storageservice.util.Conversions;
 
-class GroupsManagerTest {
+class BigTableGroupsManagerTest {
 
   private static final String GROUPS_TABLE_ID     = "groups-table";
   private static final String GROUP_LOGS_TABLE_ID = "group-logs-table";
@@ -67,7 +70,7 @@ class GroupsManagerTest {
 
   @Test
   void testCreateGroup() throws Exception {
-    GroupsManager groupsManager = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager groupsManager = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
 
     GroupSecretParams groupSecretParams = GroupSecretParams.generate();
     GroupPublicParams groupPublicParams = groupSecretParams.getPublicParams();
@@ -100,7 +103,7 @@ class GroupsManagerTest {
 
   @Test
   void testCreateGroupConflict() throws Exception {
-    GroupsManager groupsManager = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager groupsManager = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
 
     GroupSecretParams groupSecretParams = GroupSecretParams.generate();
     GroupPublicParams groupPublicParams = groupSecretParams.getPublicParams();
@@ -147,7 +150,7 @@ class GroupsManagerTest {
 
   @Test
   void testUpdateGroup() throws Exception {
-    GroupsManager groupsManager = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager groupsManager = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
 
     GroupSecretParams groupSecretParams = GroupSecretParams.generate();
     GroupPublicParams groupPublicParams = groupSecretParams.getPublicParams();
@@ -189,7 +192,7 @@ class GroupsManagerTest {
 
   @Test
   void testUpdateStaleGroup() throws Exception {
-    GroupsManager groupsManager = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager groupsManager = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
 
     GroupSecretParams groupSecretParams = GroupSecretParams.generate();
     GroupPublicParams groupPublicParams = groupSecretParams.getPublicParams();
@@ -232,7 +235,7 @@ class GroupsManagerTest {
 
   @Test
   void testGetGroup() throws Exception {
-    GroupsManager groupsManager = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager groupsManager = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
 
     GroupSecretParams groupSecretParams = GroupSecretParams.generate();
     GroupPublicParams groupPublicParams = groupSecretParams.getPublicParams();
@@ -258,7 +261,7 @@ class GroupsManagerTest {
 
   @Test
   void testGetGroupNotFound() throws Exception {
-    GroupsManager groupsManager = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager groupsManager = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
 
     GroupSecretParams groupSecretParams = GroupSecretParams.generate();
     GroupPublicParams groupPublicParams = groupSecretParams.getPublicParams();
@@ -289,7 +292,7 @@ class GroupsManagerTest {
     when(client.readRowAsync(any(TableId.class), any(ByteString.class)))
         .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("Bad news")));
 
-    GroupsManager groupsManager = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager groupsManager = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
 
     assertThatThrownBy(() -> groupsManager.getGroup(ByteString.copyFrom(new byte[16])).get())
         .isInstanceOf(ExecutionException.class)
@@ -298,7 +301,7 @@ class GroupsManagerTest {
 
   @Test
   void testAppendLog() throws ExecutionException, InterruptedException, InvalidProtocolBufferException {
-    GroupsManager     groupsManager     = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager     groupsManager     = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
     GroupSecretParams groupSecretParams = GroupSecretParams.generate();
     GroupPublicParams groupPublicParams = groupSecretParams.getPublicParams();
     ByteString        groupId           = ByteString.copyFrom(groupPublicParams.getGroupIdentifier().serialize());
@@ -340,7 +343,7 @@ class GroupsManagerTest {
 
   @Test
   void testQueryLog() throws ExecutionException, InterruptedException, InvalidProtocolBufferException {
-    GroupsManager     groupsManager     = new GroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
+    GroupsManager     groupsManager     = new BigTableGroupsManager(client, GROUPS_TABLE_ID, GROUP_LOGS_TABLE_ID);
     GroupSecretParams groupSecretParams = GroupSecretParams.generate();
     GroupPublicParams groupPublicParams = groupSecretParams.getPublicParams();
     ByteString        groupId           = ByteString.copyFrom(groupPublicParams.getGroupIdentifier().serialize());

--- a/src/test/java/org/signal/storageservice/storage/StorageManagerTest.java
+++ b/src/test/java/org/signal/storageservice/storage/StorageManagerTest.java
@@ -42,6 +42,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.signal.storageservice.auth.User;
+import org.signal.storageservice.storage.bigtable.BigTableStorageManager;
+import org.signal.storageservice.storage.bigtable.StorageItemsTable;
+import org.signal.storageservice.storage.bigtable.StorageManifestsTable;
 import org.signal.storageservice.storage.protos.contacts.StorageItem;
 import org.signal.storageservice.storage.protos.contacts.StorageManifest;
 
@@ -85,7 +88,7 @@ class StorageManagerTest {
   void testReadManifest() throws ExecutionException, InterruptedException {
     UUID userId = UUID.randomUUID();
     User user = new User(userId);
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     client.mutateRow(RowMutation.create(MANIFESTS_TABLE_ID, userId + "#manifest",
         Mutation.create()
@@ -102,7 +105,7 @@ class StorageManagerTest {
   void testGetManifestIfNotVersionDifferent() throws Exception {
     UUID userId = UUID.randomUUID();
     User user = new User(userId);
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     client.mutateRow(RowMutation.create(MANIFESTS_TABLE_ID, UUID.randomUUID() + "#manifest",
         Mutation.create()
@@ -124,7 +127,7 @@ class StorageManagerTest {
   void testGetManifestIfNotVersionSame() throws Exception {
     UUID userId = UUID.randomUUID();
     User user = new User(userId);
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     client.mutateRow(RowMutation.create(MANIFESTS_TABLE_ID, UUID.randomUUID() + "#manifest",
         Mutation.create()
@@ -148,7 +151,7 @@ class StorageManagerTest {
 
     UUID userId = UUID.randomUUID();
     User user = new User(userId);
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     assertThatThrownBy(() -> contactsManager.getManifest(user).get())
         .isInstanceOf(ExecutionException.class)
@@ -159,7 +162,7 @@ class StorageManagerTest {
   void testSetEmptyManifest() throws Exception {
     UUID userId = UUID.randomUUID();
     User user = new User(userId);
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     StorageManifest manifest = StorageManifest.newBuilder()
         .setVersion(1)
@@ -192,7 +195,7 @@ class StorageManagerTest {
   void testSetStaleManifest() throws Exception {
     UUID userId = UUID.randomUUID();
     User user = new User(userId);
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     StorageManifest manifest = StorageManifest.newBuilder()
         .setVersion(1)
@@ -242,7 +245,7 @@ class StorageManagerTest {
   void testSetUpdatedManifest() throws Exception {
     UUID userId = UUID.randomUUID();
     User user = new User(userId);
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     StorageManifest manifest = StorageManifest.newBuilder()
         .setVersion(1)
@@ -289,7 +292,7 @@ class StorageManagerTest {
   @Test
   void testSetNoMutations() {
     final User user = new User(UUID.randomUUID());
-    final StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    final StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     final StorageManifest manifest = StorageManifest.newBuilder()
         .setVersion(1)
@@ -307,7 +310,7 @@ class StorageManagerTest {
 
     UUID secondUserId = UUID.randomUUID();
 
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     for (int i = 0; i < 100; i++) {
       client.mutateRow(
@@ -381,7 +384,7 @@ class StorageManagerTest {
     UUID userId = UUID.randomUUID();
     User user = new User(userId);
 
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     for (int chunk = 0; chunk < 2; chunk++) {
       final BulkMutation bulkMutation = BulkMutation.create(CONTACTS_TABLE_ID);
@@ -417,7 +420,7 @@ class StorageManagerTest {
     UUID secondUserId = UUID.randomUUID();
     User secondUser = new User(secondUserId);
 
-    StorageManager contactsManager = new StorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
+    StorageManager contactsManager = new BigTableStorageManager(client, MANIFESTS_TABLE_ID, CONTACTS_TABLE_ID);
 
     client.mutateRow(RowMutation.create(MANIFESTS_TABLE_ID, userId + "#manifest",
         Mutation.create()


### PR DESCRIPTION
Refactor controller to use interface instead of class for managers

When we prefer not to use GCP/BigTable (e.g., when there are few users), it's beneficial to have alternative storage mechanisms. This change refactors all managers in the project to use interfaces, making it easier to implement custom solutions.

I'm not sure if this repository accepts PRs, so please let me know if there are any issues. 

Thank you!